### PR TITLE
[FIX] Version should be 1.0.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = proxmoxbmc
 summary = Create virtual BMCs for controlling virtual instances via IPMI in Proxmox VE. Based on VirtualBMC https://github.com/openstack/virtualbmc.
-version = 1.0.0
+version = 1.0.1
 description_file = README.md
 author = Marcus Nordenberg
 author_email = marcus.nordenberg@gmail.com


### PR DESCRIPTION
Fixing this error:
ValueError: git history requires a target version of pbr.version.SemanticVersion(1.0.1), but target version is pbr.version.SemanticVersion(1.0.0)