### PR TITLE
Check if pve_node is online before making further requests

### DIFF
--- a/proxmoxbmc/pbmc.py
+++ b/proxmoxbmc/pbmc.py
@@ -63,9 +63,10 @@ class ProxmoxBMC(bmc.Bmc):
 
     def _locate_vmid(self):
         for pve_node in self._proxmox.nodes.get():
-            for vm in self._proxmox.nodes(pve_node['node']).qemu.get():
-                if str(vm['vmid']) == self.vmid:                    
-                    return pve_node
+            if str(pve_node['status']) == 'online':
+                for vm in self._proxmox.nodes(pve_node['node']).qemu.get():
+                    if str(vm['vmid']) == self.vmid:                    
+                        return pve_node
             
         return None
 


### PR DESCRIPTION
Otherwise there might be errors like 

```txt
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "~/.venvs/proxmoxbmc/lib/python3.11/site-packages/proxmoxer/core.py", line 143, in get
    return self(args)._request("GET", params=params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.venvs/proxmoxbmc/lib/python3.11/site-packages/proxmoxer/core.py", line 123, in _request
    raise ResourceException(
proxmoxer.core.ResourceException: 595 Errors during connection establishment, proxy handshake: No route to host - {'errors': b''}
```