### PR TITLE
Add Debian packaging

### DIFF
--- a/proxmoxbmc/debian/changelog
+++ b/proxmoxbmc/debian/changelog
@@ -1,0 +1,17 @@
+proxmoxbmc (1.0.1-2) unstable; urgency=medium
+
+  * Add systemd unit file -- pbmcd now installs and enables as a proper
+    system service via dh_installsystemd. Service starts automatically
+    on boot after network-online.target and pve-cluster.service.
+
+ -- knightmare2600 <knightmare2600@gmail.com>  Sun, 22 Mar 2026 10:00:00 +0000
+
+proxmoxbmc (1.0.1-1) unstable; urgency=medium
+
+  * Initial Debian packaging.
+  * All dependencies satisfied by Debian/Proxmox apt packages --
+    no pip or venv required.
+  * Installs pbmc and pbmcd binaries to /usr/bin/.
+  * Suitable for submission to Debian via the OpenStack team.
+
+ -- knightmare2600 <knightmare2600@gmail.com>    Sun, 22 Mar 2026 09:00:00 +0000

--- a/proxmoxbmc/debian/contorl
+++ b/proxmoxbmc/debian/contorl
@@ -1,0 +1,41 @@
+Source: proxmoxbmc
+Section: python
+Priority: optional
+Maintainer: Marcus Nordenberg <marcus.nordenberg@gmail.com>
+Uploaders: Marcus Nordenberg <marcus.nordenberg@gmail.com>
+Build-Depends:
+ debhelper-compat (= 13),
+ dh-python,
+ python3-all,
+ python3-setuptools,
+ python3-pbr
+Standards-Version: 4.6.2
+Homepage: https://github.com/agnon/proxmoxbmc
+Rules-Requires-Root: no
+
+Package: python3-proxmoxbmc
+Architecture: all
+Depends:
+ ${python3:Depends},
+ ${misc:Depends},
+ python3-pyghmi (>= 1.2.0),
+ python3-cliff (>= 2.8.0),
+ python3-zmq (>= 19.0.0),
+ python3-proxmoxer (>= 1.3.0),
+ python3-requests,
+ python3-pbr (>= 2.0.0)
+Description: Virtual BMC for controlling Proxmox VMs via IPMI
+ proxmoxbmc provides a virtual Baseboard Management Controller (BMC)
+ for Proxmox VE virtual machines. It allows IPMI clients such as
+ ipmitool to control VMs via the IPMI protocol, enabling power control,
+ boot device selection, and Serial over LAN (SOL) console access.
+ .
+ Based on OpenStack VirtualBMC, adapted to use the Proxmox VE API
+ via proxmoxer instead of libvirt. Each VM is exposed on its own
+ UDP port. The pbmcd daemon manages the BMC instances and the pbmc
+ command-line tool registers and controls them.
+ .
+ Useful for testing IPMI-based automation tools (Ansible IPMI modules,
+ OpenStack Ironic, PXE boot orchestration) and for providing
+ technicians with ipmitool-compatible access to VMs for power control
+ and SOL serial console rescue.

--- a/proxmoxbmc/debian/copyright
+++ b/proxmoxbmc/debian/copyright
@@ -1,0 +1,15 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: proxmoxbmc
+Upstream-Contact: Marcus Nordenberg <marcus.nordenberg@gmail.com>
+Source: https://github.com/agnon/proxmoxbmc
+
+Files: *
+Copyright: 2022 Marcus Nordenberg <marcus.nordenberg@gmail.com>
+           2016 OpenStack Foundation
+License: Apache-2.0
+
+License: Apache-2.0
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ On Debian systems, the full text of the Apache-2.0 license can be
+ found in /usr/share/common-licenses/Apache-2.0.

--- a/proxmoxbmc/debian/proxmoxbmc.service
+++ b/proxmoxbmc/debian/proxmoxbmc.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=proxmoxbmc -- Virtual BMC for Proxmox VE VMs
+Documentation=https://github.com/agnon/proxmoxbmc
+After=network-online.target pve-cluster.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/bin/pbmcd --foreground
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=20
+
+# Ensure state directory exists for pbmc database
+RuntimeDirectory=proxmoxbmc
+StateDirectory=proxmoxbmc
+
+[Install]
+WantedBy=multi-user.target

--- a/proxmoxbmc/debian/rules
+++ b/proxmoxbmc/debian/rules
@@ -1,0 +1,8 @@
+#!/usr/bin/make -f
+export PYBUILD_NAME=proxmoxbmc
+
+%:
+	dh $@ --with python3 --buildsystem=pybuild
+
+override_dh_installsystemd:
+	dh_installsystemd --name=proxmoxbmc


### PR DESCRIPTION
I have add Debian packaging (debian/ directory)

This adds a debian/ directory so proxmoxbmc can be built as a native .deb package with no pip, venv, or git clone required at install time. All dependencies map to packaged python3-* apt packages available in Debian trixie (and therefore Proxmox 8/9):

python3-pyghmi
python3-cliff
python3-zmq
python3-proxmoxer
python3-pbr
python3-requests

The package also includes a systemd unit file (proxmoxbmc.service) with After=pve-cluster.service so the daemon starts correctly on Proxmox nodes. dh_installsystemd wires up enable/start on install and stop on remove automatically.
Tested: built and verified on Ubuntu Noble (same package set as Proxmox 8 trixie). The resulting .deb is 15K, architecture-independent (all).

This could also serve as the basis for a submission to Debian proper via the OpenStack packaging team if there's interest.

Installs:
  - pbmc and pbmcd to /usr/bin/
  - Python module to /usr/lib/python3/dist-packages/
  - proxmoxbmc.service to /usr/lib/systemd/system/

The service is enabled and started automatically on dpkg -i via dh_installsystemd hooks in postinst/prerm.

Build with:
  apt-get install debhelper dh-python python3-all python3-setuptools python3-pbr
  dpkg-buildpackage -us -uc -b"
